### PR TITLE
Gradle 7.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Sep 28 11:26:39 PDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.0 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/minoibno/mock-oauth2-server/status for more.